### PR TITLE
Add payment_reminder email, manually trigger email re-sends, and minor formatting changes #minor

### DIFF
--- a/competition/management/commands/add_email_templates.py
+++ b/competition/management/commands/add_email_templates.py
@@ -17,6 +17,7 @@ class Command(BaseCommand):
             "daily_email.html": "Place your predictions for today's matches",
             "final_reminder.html": "Last chance to place your EURO 2024 Champion prediction",
             "welcome_email.html": "Welcome to the MS Risk 2024 EURO Prediction Game",
+            "payment_reminder": "MS Risk 2024 EURO Prediction Game",
         }.items():
             with open(os.path.join("templates", "emails", file_name), "r") as file:
                 file_contents = file.read()

--- a/competition/tasks.py
+++ b/competition/tasks.py
@@ -150,7 +150,8 @@ def payment_reminder_email(user_pk, cc=[]):
             email_template = file.read()
             email_body = email_template
         if len(email_template) == 0:
-            email_template = EmailTemplates(name="payment_reminder", html=email_body).save()
+            email_template = EmailTemplates(name="payment_reminder", html=email_body)
+            email_template.save()
     else:
         email_template = email_template.first()
 

--- a/competition/tasks.py
+++ b/competition/tasks.py
@@ -20,6 +20,7 @@ def __get_email_template(template_name):
         # add template if does not exist
         if len(email_obj) == 0:
             email_obj = EmailTemplates(name=template_name, html=email_body)
+            email_obj.save()
 
     else:
         email_obj = email_obj.first()

--- a/general/admin.py
+++ b/general/admin.py
@@ -190,7 +190,7 @@ def send_test_email(modeladmin, request, queryset):
                     user_obj.pk,
                 ],
             )
-        elif test_template.name == "final_reminder":
+        elif test_template.name == "payment_reminder":
             app.send_task(
                 "competition.tasks.payment_reminder_email",
                 args=[user_obj.pk, [user_obj.pk]],

--- a/general/admin.py
+++ b/general/admin.py
@@ -85,7 +85,7 @@ def send_payment_reminder_email(modeladmin, request, queryset):
     for user_obj in queryset:
         print(f"Sending payment reminder email to {user_obj.username} triggered by {request.user.username}")
         app.send_task(
-            "competition.tasks.payment_reminder",
+            "competition.tasks.payment_reminder_email",
             args=[user_obj.pk, [request.user.pk]],
         )
 
@@ -192,7 +192,7 @@ def send_test_email(modeladmin, request, queryset):
             )
         elif test_template.name == "final_reminder":
             app.send_task(
-                "competition.tasks.final_reminder",
+                "competition.tasks.payment_reminder_email",
                 args=[user_obj.pk, [user_obj.pk]],
             )
 

--- a/general/admin.py
+++ b/general/admin.py
@@ -190,6 +190,11 @@ def send_test_email(modeladmin, request, queryset):
                     user_obj.pk,
                 ],
             )
+        elif test_template.name == "final_reminder":
+            app.send_task(
+                "competition.tasks.final_reminder",
+                args=[user_obj.pk, [user_obj.pk]],
+            )
 
 
 @admin.register(EmailTemplates)

--- a/general/admin.py
+++ b/general/admin.py
@@ -40,10 +40,66 @@ class TournamentBetInline(admin.TabularInline):
     can_delete = False
 
 
+@admin.action(description="Send welcome email again to user")
+def send_weclome_email_again(modeladmin, request, queryset):
+    """admin action for users to re-send welcome email to user"""
+    for user_obj in queryset:
+        print(f"Sending welcome email again to {user_obj.username} triggered by {request.user.username}")
+        app.send_task(
+            "competition.tasks.welcome_email",
+            args=[
+                user_obj.pk,
+            ],
+        )
+
+
+@admin.action(description="Send final reminder email again to user")
+def send_final_reminder_email_again(modeladmin, request, queryset):
+    """admin action for users to re-send final reminder email to user"""
+    for user_obj in queryset:
+        print(f"Sending final remindeer email again to {user_obj.username} triggered by {request.user.username}")
+        app.send_task(
+            "competition.tasks.last_admission_email",
+            args=[
+                user_obj.pk,
+            ],
+        )
+
+
+@admin.action(description="Send daily email again to user")
+def send_daily_email_again(modeladmin, request, queryset):
+    """admin action for users to re-send daily email to user"""
+    for user_obj in queryset:
+        print(f"Sending daily email again to {user_obj.username} triggered by {request.user.username}")
+        app.send_task(
+            "competition.tasks.daily_matchday_email",
+            args=[
+                user_obj.pk,
+            ],
+        )
+
+
+@admin.action(description="Send payment reminder to user")
+def send_payment_reminder_email(modeladmin, request, queryset):
+    """admin action for users to send payment remidner email to user"""
+    for user_obj in queryset:
+        print(f"Sending payment reminder email to {user_obj.username} triggered by {request.user.username}")
+        app.send_task(
+            "competition.tasks.payment_reminder",
+            args=[user_obj.pk, [request.user.pk]],
+        )
+
+
 class CustomUserAdmin(UserAdmin):
     """Amin view of Custom User model - needed to use email as login and a few more additional fields"""
 
     add_form = CustomUserCreationForm
+    actions = [
+        send_weclome_email_again,
+        send_final_reminder_email_again,
+        send_daily_email_again,
+        send_payment_reminder_email,
+    ]
     form = CustomUserChangeForm
     model = CustomUser
     list_display = (

--- a/templates/emails/payment_reminder.html
+++ b/templates/emails/payment_reminder.html
@@ -1,0 +1,14 @@
+<tr>
+    <td class="wrapper">
+        <p>Hi {first_name},</p>
+        <p>Kind reinder to please transfer the participation fee of £5 for the MS Risk 2024 EURO Prediction Game!</p>
+        <p>You can either:</p>
+        <ul>
+            <li>Use this link ??????????????????.</li>
+            <li>Or use the QR-Code below:</li>
+        </ul>
+        <img src="{qr_image_link}" width="200">
+        <p>Thanks a lot,</p>
+        <p>Your London Risk Social Network.</p>
+    </td>
+</tr>

--- a/templates/emails/welcome_email.html
+++ b/templates/emails/welcome_email.html
@@ -7,7 +7,7 @@
             <li>Please click <a href="{verify_link}" target="_blank">this link</a> to verify your email address.</li>
             <li>And transfer the participation fee of £5 to ???????????????????????? or use the QR-Code below:</li>
         </ul>
-        <img src="{qr_image_link}" width="200px">
+        <img src="{qr_image_link}" width="200">
         <p>The rules summarized:</p>
         <ul>
             <li>Before the first game starts (i.e. Saturday, June 14th - 8:00 p.m.), predict the 2024 EURO champion (after June 14th - 8:00 p.m. a change is no longer possible).</li>

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -25,7 +25,7 @@
             </div>
 
 
-            <div class="container m-3">
+            <div class="container m-3" style="width: 100%; max-width: 100%;">
                 <hr class="featurette-divider my-4">
                 {% for date, match_lst in match_dict.items %}
                     <h4>{{ date|date:'l j F o' }}</h4>


### PR DESCRIPTION
- [Add option to manually re-send emails, add payment remidner email, mi…](https://github.com/vanalmsick/sweepstake/commit/463c37aa7fe38567cbff4b45c9f55cb5b736fbce)
- [Add payment reminder test email option to admin view. #patch](https://github.com/vanalmsick/sweepstake/commit/4cb7457073495f029c12d55b9ab1e0108af67df5)
- [Add payment_reminder email template. #patch](https://github.com/vanalmsick/sweepstake/commit/85faf2f98cd4c47ddd19053609356c820580e0e9)